### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/css/dark-mode.css
+++ b/assets/css/dark-mode.css
@@ -1,0 +1,31 @@
+body.dark-mode {
+    background: #121212;
+    color: #e0e0e0;
+}
+body.dark-mode a {
+    color: #80cbc4;
+}
+body.dark-mode .wrapper,
+body.dark-mode .sidebar-wrapper {
+    background: #333;
+    color: #fff;
+}
+body.dark-mode .main-wrapper {
+    background: #222;
+}
+body.dark-mode .section-title {
+    color: #e0e0e0;
+}
+body.dark-mode .section-title .icon-holder {
+    background: #80cbc4;
+}
+body.dark-mode .skillset .level-bar {
+    background: #555;
+}
+body.dark-mode .skillset .theme-progress-bar {
+    background: #80cbc4;
+}
+body.dark-mode .footer {
+    background: #121212;
+    color: #aaa;
+}

--- a/index.html
+++ b/index.html
@@ -21,9 +21,11 @@
     <link rel="stylesheet" href="assets/plugins/bootstrap/css/bootstrap.min.css">   
     <!-- Theme CSS -->  
     <link id="theme-style" rel="stylesheet" href="assets/css/orbit-6.css">
+    <link rel="stylesheet" href="assets/css/dark-mode.css">
 </head> 
 
 <body>
+    <button id="dark-mode-toggle" class="btn btn-light" style="position: fixed; top: 10px; right: 10px; z-index: 1000;">Modo Escuro</button>
     <div class="wrapper">
         <div class="sidebar-wrapper">
             <div class="profile-container">
@@ -235,7 +237,23 @@
                 
         </div><!--//container-->
     </footer><!--//footer-->
-        
+
+    <script>
+        (function() {
+            var btn = document.getElementById('dark-mode-toggle');
+            var stored = localStorage.getItem('theme');
+            if (stored === 'dark') {
+                document.body.classList.add('dark-mode');
+                btn.textContent = 'Modo Claro';
+            }
+            btn.addEventListener('click', function() {
+                var isDark = document.body.classList.toggle('dark-mode');
+                btn.textContent = isDark ? 'Modo Claro' : 'Modo Escuro';
+                localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            });
+        })();
+    </script>
+
 </body>
-</html> 
+</html>
 


### PR DESCRIPTION
## Summary
- enable dark-mode styles
- add button to toggle dark mode
- store user's choice in local storage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68479e5ad970832e93691b6531566ccd